### PR TITLE
feat: Switch to single-switch coq images

### DIFF
--- a/images.yml
+++ b/images.yml
@@ -2,18 +2,19 @@
 base_url: 'https://gitlab.com/math-comp/docker-mathcomp'
 active: true
 args:
-  COQ_TAG: '{matrix[coq]}'
+  COQ_TAG: '{matrix[coq]}-ocaml-{matrix[ocaml]}'
   MATHCOMP_VERSION: '{matrix[mathcomp]}'
 docker_repo: 'mathcomp/mathcomp'
 images:
   # to uncomment for next beta
   # - matrix:
+  #     ocaml: ['4.07-flambda']
   #     coq: ['dev']
   #     mathcomp: ['1.12+beta1']
   #   build:
   #     nightly: true
   #     context: './mathcomp'
-  #     dockerfile: './dual/Dockerfile'
+  #     dockerfile: './single/Dockerfile'
   #     tags:
   #       - tag: '{matrix[mathcomp][//+/-]}-coq-{matrix[coq]}'
   # - matrix:
@@ -21,60 +22,66 @@ images:
   #     mathcomp: ['1.12+beta1']
   #   build:
   #     context: './mathcomp'
-  #     dockerfile: './dual/Dockerfile'
+  #     dockerfile: './single/Dockerfile'
   #     tags:
   #       - tag: '{matrix[mathcomp][//+/-]}-coq-{matrix[coq]}'
   - matrix:
+      ocaml: ['4.07-flambda']
       coq: ['dev']
       mathcomp: ['1.11.0']
     build:
       nightly: true
       context: './mathcomp'
-      dockerfile: './dual/Dockerfile'
+      dockerfile: './single/Dockerfile'
       tags:
         - tag: '{matrix[mathcomp]}-coq-{matrix[coq]}'
         # to remove on next release
         - tag: 'latest-coq-{matrix[coq]}'
   - matrix:
+      ocaml: ['4.07-flambda']
       coq: ['8.12', '8.11', '8.10', '8.9', '8.8', '8.7']
       mathcomp: ['1.11.0']
     build:
       context: './mathcomp'
-      dockerfile: './dual/Dockerfile'
+      dockerfile: './single/Dockerfile'
       tags:
         - tag: '{matrix[mathcomp]}-coq-{matrix[coq]}'
         # to remove on next release
         - tag: 'latest-coq-{matrix[coq]}'
   - matrix:
+      ocaml: ['4.07-flambda']
       coq: ['8.11', '8.10', '8.9', '8.8', '8.7']
       mathcomp: ['1.10.0']
     build:
       context: './mathcomp'
-      dockerfile: './dual/Dockerfile'
+      dockerfile: './single/Dockerfile'
       tags:
         - tag: '{matrix[mathcomp]}-coq-{matrix[coq]}'
   - matrix:
+      ocaml: ['4.07-flambda']
       coq: ['8.11', '8.10', '8.9', '8.8', '8.7']
       mathcomp: ['1.9.0']
     build:
       context: './mathcomp'
-      dockerfile: './dual/Dockerfile'
+      dockerfile: './single/Dockerfile'
       tags:
         - tag: '{matrix[mathcomp]}-coq-{matrix[coq]}'
   - matrix:
+      ocaml: ['4.07-flambda']
       coq: ['8.9', '8.8', '8.7']
       mathcomp: ['1.8.0']
     build:
       context: './mathcomp'
-      dockerfile: './dual/Dockerfile'
+      dockerfile: './single/Dockerfile'
       tags:
         - tag: '{matrix[mathcomp]}-coq-{matrix[coq]}'
   - matrix:
+      ocaml: ['4.07-flambda']
       coq: ['8.9', '8.8', '8.7']
       mathcomp: ['1.7.0']
     build:
       context: './mathcomp'
-      dockerfile: './dual/Dockerfile'
+      dockerfile: './single/Dockerfile'
       tags:
         - tag: '{matrix[mathcomp]}-coq-{matrix[coq]}'
   - matrix:
@@ -83,5 +90,7 @@ images:
     build:
       context: './mathcomp'
       dockerfile: './single/Dockerfile'
+      args:
+        COQ_TAG: '{matrix[coq]}'
       tags:
         - tag: '{matrix[mathcomp]}-coq-{matrix[coq]}'


### PR DESCRIPTION
* Use `coqorg/coq:*-ocaml-4.07-flambda`

    (this ocaml switch version was already that of mathcomp/mathcomp-dev)

* This should be merged and deployed (rebuilt with a manual GitLab CI pipeline) *after* PR coq-community/docker-coq#7 is merged and deployed.