### PR TITLE
Remove mathcomp/mathcomp:latest-coq-dev (for 1.11.0)

### DIFF
--- a/images.yml
+++ b/images.yml
@@ -25,17 +25,6 @@ images:
   #     tags:
   #       - tag: '{matrix[mathcomp][//+/-]}-coq-{matrix[coq]}'
   - matrix:
-      coq: ['dev']
-      mathcomp: ['1.11.0']
-    build:
-      nightly: true
-      context: './mathcomp'
-      dockerfile: './dual/Dockerfile'
-      tags:
-        - tag: '{matrix[mathcomp]}-coq-{matrix[coq]}'
-        # to remove on next release
-        - tag: 'latest-coq-{matrix[coq]}'
-  - matrix:
       coq: ['8.12', '8.11', '8.10', '8.9', '8.8', '8.7']
       mathcomp: ['1.11.0']
     build:


### PR DESCRIPTION
* the latest mathcomp release does not build anymore with coq.dev

* first spotted on 2020-08-21 04:07 UTC+2:
  https://gitlab.com/math-comp/docker-mathcomp/-/jobs/696802737 (GitLab CI nightly build)
  Cc @CohenCyril FYI (sorry for the delay for opening this PR… I will merge it as soon as the GitLab CI passes, and open a PR in opam-coq-archive accordingly)