### PR TITLE
fix: Workaround #12

### DIFF
--- a/mathcomp/dual/Dockerfile
+++ b/mathcomp/dual/Dockerfile
@@ -23,15 +23,10 @@ RUN set -x \
 
 # hadolint ignore=SC2046
 RUN set -x \
-  && eval $(opam env "--switch=${COMPILER}" --set-switch) \
-  && opam update -y -u \
-  && opam pin add -n -k version coq-mathcomp-ssreflect ${MATHCOMP_VERSION} \
-  && opam pin add -n -k version coq-mathcomp-fingroup ${MATHCOMP_VERSION} \
-  && opam pin add -n -k version coq-mathcomp-algebra ${MATHCOMP_VERSION} \
-  && opam pin add -n -k version coq-mathcomp-solvable ${MATHCOMP_VERSION} \
-  && opam pin add -n -k version coq-mathcomp-field ${MATHCOMP_VERSION} \
-  && opam pin add -n -k version coq-mathcomp-character ${MATHCOMP_VERSION} \
-  && opam install -y -j "${NJOBS}" ${MATHCOMP_PACKAGE} \
+  # Workaround https://github.com/math-comp/docker-mathcomp/issues/12
+  && opam switch "${COMPILER_EDGE}" \
+  && eval $(opam env) \
+  && opam switch remove -y "${COMPILER}" \
   && opam clean -a -c -s --logs \
   && opam config list && opam list
 


### PR DESCRIPTION
* Summary: Ditch 4.05.0 in mathcomp/mathcomp stable images

* Related: https://github.com/coq-community/docker-coq/issues/30