### PR TITLE
Remove the mathcomp/mathcomp:1.14.0-coq-dev image

### DIFF
--- a/images.yml
+++ b/images.yml
@@ -23,7 +23,7 @@ images:
   #       # - tag: 'latest-coq-{matrix[coq]}'
 
   - matrix:
-      coq: ['dev', '8.15', '8.14', '8.13', '8.12', '8.11']
+      coq: ['8.15', '8.14', '8.13', '8.12', '8.11']
       mathcomp: ['1.14.0']
     build:
       # keyword for docker-keeper's trigger (from docker-coq CI)


### PR DESCRIPTION
Its build fails here (fixed in math-comp/math-comp#857): https://github.com/math-comp/math-comp/blob/mathcomp-1.14.0/mathcomp/algebra/rat.v#L541

This failure also prevents us from deploying other images.