### PR TITLE
Add 2.4.0-rocq-prover-9.1

### DIFF
--- a/images.yml
+++ b/images.yml
@@ -60,7 +60,7 @@ images:
           if: '{matrix[coq][%.*]} == 8'
 
   - matrix:
-      coq: ['dev', '9.0', '8.20', '8.19']
+      coq: ['dev', '9.1', '9.0', '8.20', '8.19']
       mathcomp: ['2.4.0']
     build:
       # keyword for docker-keeper's trigger (from docker-rocq CI)


### PR DESCRIPTION
Besides that, `mathcomp/mathcomp:2.5.0-rocq-prover-dev` and `mathcomp/mathcomp-dev:rocq-prover-9.1` seem still lacking (on Docker Hub), although the former is already listed in `images.yml`. Any idea on how to fix it?